### PR TITLE
add Perl 5.6 support

### DIFF
--- a/Int64.xs
+++ b/Int64.xs
@@ -6,6 +6,8 @@
 #include "perl.h"
 #include "XSUB.h"
 
+#define NEED_sv_2pvbyte
+#define NEED_sv_2pv_flags
 #include "ppport.h"
 
 static int may_die_on_overflow;

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,5 @@
 Makefile.PL
+c_api.h
 Changes
 README
 MANIFEST
@@ -27,4 +28,5 @@ c_api.decl
 c_api.h
 templates/module_c.temp
 templates/module_h.temp
+typemap
 examples/rand64.pl

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,3 @@
-use 5.008;
-
 use ExtUtils::MakeMaker;
 
 use Config;

--- a/c_api.h
+++ b/c_api.h
@@ -1,0 +1,31 @@
+/*
+ * c_api.h - This file is in the public domain
+ * Author: Salvador Fandino <sfandino@yahoo.com>
+ *
+ * Generated on: 2012-12-10 21:34:09
+ * Math::Int64 version: 0.28
+ * Module::CAPIMaker version: 0.02
+ */
+
+#if !defined (C_API_H_INCLUDED)
+#define C_API_H_INCLUDED
+
+static void
+init_c_api(pTHX) {
+    HV *hv = get_hv("Math::Int64::C_API", TRUE|GV_ADDMULTI);
+    hv_store(hv, "min_version", 11, newSViv(1), 0);
+    hv_store(hv, "max_version", 11, newSViv(2), 0);
+    hv_store(hv, "version", 7, newSViv(2), 0);
+    hv_store(hv, "SvI64", 5, newSViv(PTR2IV(&SvI64)), 0);
+    hv_store(hv, "SvI64OK", 7, newSViv(PTR2IV(&SvI64OK)), 0);
+    hv_store(hv, "SvU64", 5, newSViv(PTR2IV(&SvU64)), 0);
+    hv_store(hv, "SvU64OK", 7, newSViv(PTR2IV(&SvU64OK)), 0);
+    hv_store(hv, "newSVi64", 8, newSViv(PTR2IV(&newSVi64)), 0);
+    hv_store(hv, "newSVu64", 8, newSViv(PTR2IV(&newSVu64)), 0);
+    hv_store(hv, "randU64", 7, newSViv(PTR2IV(&randU64)), 0);
+
+}
+
+#define INIT_C_API init_c_api(aTHX)
+
+#endif

--- a/typemap
+++ b/typemap
@@ -1,0 +1,1 @@
+const char *		T_PV


### PR DESCRIPTION
Added support for Perl 5.6 to Math::Int64. c_api.h was in the CPAN 0.28 but not in git so I added it. MANIFEST should also be regenerated since there is a wide difference between the MANIFEST file and what is actually in the repo/archive. sortable.t fails for an obvious reason.

C:\Documents and Settings\Owner\Desktop\cpan libs\mi64>perl -V
Summary of my perl5 (revision 5 version 6 subversion 2) configuration:
  Platform:
    osname=MSWin32, osvers=4.0, archname=MSWin32-x86
    uname=''
    config_args='undef'
    hint=recommended, useposix=true, d_sigaction=undef
    usethreads=undef use5005threads=undef useithreads=undef usemultiplicity=unde
f
    useperlio=undef d_sfio=undef uselargefiles=undef usesocks=undef
    use64bitint=undef use64bitall=undef uselongdouble=undef
  Compiler:
    cc='cl', ccflags ='-nologo -Od -Zi -MD -DNDEBUG -DWIN32 -D_CONSOLE -DNO_STRI
CT -DHAVE_DES_FCRYPT  -DPERL_MSVCRT_READFIX',
    optimize='-Od -Zi -MD -DNDEBUG',
    cppflags='-DWIN32'
    ccversion='', gccversion='', gccosandvers=''
    intsize=4, longsize=4, ptrsize=4, doublesize=8, byteorder=1234
    d_longlong=undef, longlongsize=8, d_longdbl=define, longdblsize=10
    ivtype='long', ivsize=4, nvtype='double', nvsize=8, Off_t='off_t', lseeksize
=4
    alignbytes=8, usemymalloc=n, prototype=define
  Linker and Libraries:
    ld='link', ldflags ='-nologo -nodefaultlib -debug -opt:ref,icf -release  -li
bpath:"c:\p56\5.6.2\lib\MSWin32-x86\CORE"  -machine:x86'
    libpth="C:\Program Files\Microsoft Visual Studio .NET 2003\VC7\lib"
    libs=  oldnames.lib kernel32.lib user32.lib gdi32.lib winspool.lib  comdlg32
.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib  netapi32.lib uuid.lib wsoc
k32.lib mpr.lib winmm.lib  version.lib odbc32.lib odbccp32.lib msvcrt.lib
    perllibs=  oldnames.lib kernel32.lib user32.lib gdi32.lib winspool.lib  comd
lg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib  netapi32.lib uuid.lib
wsock32.lib mpr.lib winmm.lib  version.lib odbc32.lib odbccp32.lib msvcrt.lib
    libc=msvcrt.lib, so=dll, useshrplib=yes, libperl=perl56.lib
  Dynamic Linking:
    dlsrc=dl_win32.xs, dlext=dll, d_dlsymun=undef, ccdlflags=' '
    cccdlflags=' ', lddlflags='-dll -nologo -nodefaultlib -debug -opt:ref,icf  -
release  -libpath:"c:\p56\5.6.2\lib\MSWin32-x86\CORE"  -machine:x86'

Characteristics of this binary (from libperl):
  Compile-time options:
  Built under MSWin32
  Compiled at Jan  5 2013 15:16:37
  %ENV:
    PERL_JSON_BACKEND="JSON::XS"
    PERL_YAML_BACKEND="YAML"
  @INC:
    C:/p56/5.6.2/lib/MSWin32-x86
    C:/p56/5.6.2/lib
    C:/p56/site/5.6.2/lib/MSWin32-x86
    C:/p56/site/5.6.2/lib
    .

C:\Documents and Settings\Owner\Desktop\cpan libs\mi64>perl makefile.pl
Using NV backend
Checking if your kit is complete...
Warning: the following files are missing in your kit:
        c_api_client/perl_math_int64.c
        c_api_client/perl_math_int64.h
Please inform the author.
Writing Makefile for Math::Int64

C:\Documents and Settings\Owner\Desktop\cpan libs\mi64>nmake test

Microsoft (R) Program Maintenance Utility Version 7.10.3077
Copyright (C) Microsoft Corporation.  All rights reserved.

cp lib/Math/Int64.pm blib\lib\Math\Int64.pm
cp lib/Math/Int64/native_if_available.pm blib\lib\Math\Int64\native_if_available
.pm
cp lib/Math/Int64/die_on_overflow.pm blib\lib\Math\Int64\die_on_overflow.pm
cp lib/Math/UInt64.pm blib\lib\Math\UInt64.pm
        C:\p56\5.6.2\bin\MSWin32-x86\perl.exe C:\p56\5.6.2\lib\ExtUtils/xsubpp
-typemap C:\p56\5.6.2\lib\ExtUtils\typemap -typemap typemap  Int64.xs > Int64.xs
c && C:\p56\5.6.2\bin\MSWin32-x86\perl.exe -MExtUtils::Command -e mv Int64.xsc I
nt64.c
        cl -c  -I.  -nologo -Od -Zi -MD -DNDEBUG -DWIN32 -D_CONSOLE -DNO_STRICT
-DHAVE_DES_FCRYPT -DPERL_MSVCRT_READFIX -Od -Zi -MD -DNDEBUG    -DVERSION=\"0.28
\"  -DXS_VERSION=\"0.28\"  "-IC:\p56\5.6.2\lib\MSWin32-x86\CORE"  -DINT64_BACKEN
D_NV Int64.c
Int64.c
Running Mkbootstrap for Math::Int64 ()
        C:\p56\5.6.2\bin\MSWin32-x86\perl.exe -MExtUtils::Command -e chmod 644 I
nt64.bs
        C:\p56\5.6.2\bin\MSWin32-x86\perl.exe -MExtUtils::Mksymlists  -e "Mksyml
ists('NAME'=>\"Math::Int64\", 'DLBASE' => 'Int64', 'DL_FUNCS' => {  }, 'FUNCLIST
' => [], 'IMPORTS' => {  }, 'DL_VARS' => []);"
        link -out:blib\arch\auto\Math\Int64\Int64.dll -dll -nologo -nodefaultlib
 -debug -opt:ref,icf  -release  -libpath:"c:\p56\5.6.2\lib\MSWin32-x86\CORE"  -m
achine:x86 Int64.obj   C:\p56\5.6.2\lib\MSWin32-x86\CORE\perl56.lib oldnames.lib
 kernel32.lib user32.lib gdi32.lib winspool.lib  comdlg32.lib advapi32.lib shell
32.lib ole32.lib oleaut32.lib  netapi32.lib uuid.lib wsock32.lib mpr.lib winmm.l
ib  version.lib odbc32.lib odbccp32.lib msvcrt.lib -def:Int64.def
   Creating library blib\arch\auto\Math\Int64\Int64.lib and object blib\arch\aut
o\Math\Int64\Int64.exp
        C:\p56\5.6.2\bin\MSWin32-x86\perl.exe -MExtUtils::Command -e chmod 755 b
lib\arch\auto\Math\Int64\Int64.dll
        C:\p56\5.6.2\bin\MSWin32-x86\perl.exe -MExtUtils::Command -e cp Int64.bs
 blib\arch\auto\Math\Int64\Int64.bs
        C:\p56\5.6.2\bin\MSWin32-x86\perl.exe -MExtUtils::Command -e chmod 644 b
lib\arch\auto\Math\Int64\Int64.bs
        C:\p56\5.6.2\bin\MSWin32-x86\perl.exe "-MExtUtils::Command::MM" "-e" "te
st_harness(0, 'blib\lib', 'blib\arch')" t\as_int64.t t\die_on_overflow.t t\Math-
Int64-Native.t t\Math-Int64.t t\Math-UInt64-Native.t t\Math-UInt64.t t\MSC.t t\p
ods.t t\pow.t t\storable.t
t\as_int64..............ok
t\die_on_overflow.......ok
        30/78 skipped: lexical pragmas require perl 5.10 or later
t\Math-Int64-Native.....ok
        9/48 skipped: various reasons
t\Math-Int64............ok
t\Math-UInt64-Native....ok
        6/37 skipped: various reasons
t\Math-UInt64...........ok
t\MSC...................ok
t\pods..................skipped
        all skipped: Only the author needs to check that POD docs are right
t\pow...................ok
t\storable..............Can't locate Storable.pm in @INC (@INC contains: C:\Docu
ments and Settings\Owner\Desktop\cpan libs\mi64\blib\lib C:\Documents and Settin
gs\Owner\Desktop\cpan libs\mi64\blib\arch C:/p56/5.6.2/lib/MSWin32-x86 C:/p56/5.
6.2/lib/MSWin32-x86 C:/p56/5.6.2/lib C:/p56/site/5.6.2/lib/MSWin32-x86 C:/p56/si
te/5.6.2/lib/MSWin32-x86 C:/p56/site/5.6.2/lib . C:/p56/5.6.2/lib/MSWin32-x86 C:
/p56/5.6.2/lib C:/p56/site/5.6.2/lib/MSWin32-x86 C:/p56/site/5.6.2/lib .) at t\s
torable.t line 8.
BEGIN failed--compilation aborted at t\storable.t line 8.
t\storable..............dubious
        Test returned status 2 (wstat 512, 0x200)
DIED. FAILED tests 1-200
        Failed 200/200 tests, 0.00% okay
## Failed Test  Stat Wstat Total Fail  Failed  List of Failed

t\storable.t    2   512   200  400 200.00%  1-200
1 test and 45 subtests skipped.
Failed 1/10 test scripts, 90.00% okay. 200/1613 subtests failed, 87.60% okay.
NMAKE : fatal error U1077: 'C:\p56\5.6.2\bin\MSWin32-x86\perl.exe' : return code
 '0x2'
Stop.

C:\Documents and Settings\Owner\Desktop\cpan libs\mi64>nmake install

Microsoft (R) Program Maintenance Utility Version 7.10.3077
Copyright (C) Microsoft Corporation.  All rights reserved.

Installing C:\p56\site\5.6.2\lib\MSWin32-x86\auto\Math\Int64\Int64.dll
Installing C:\p56\site\5.6.2\lib\MSWin32-x86\auto\Math\Int64\Int64.exp
Installing C:\p56\site\5.6.2\lib\MSWin32-x86\auto\Math\Int64\Int64.lib
Installing C:\p56\site\5.6.2\lib\MSWin32-x86\auto\Math\Int64\Int64.pdb
Files found in blib\arch: installing files in blib\lib into architecture depende
nt library tree
Writing c:\p56\site\5.6.2\lib\MSWin32-x86\auto\Math\Int64.packlist
Appending installation info to c:\p56\5.6.2\lib\MSWin32-x86/perllocal.pod

C:\Documents and Settings\Owner\Desktop\cpan libs\mi64>
