### PR TITLE
Fix failure to include stdint.h with VS 2010 or newer

### DIFF
--- a/Int64.xs
+++ b/Int64.xs
@@ -27,6 +27,10 @@ static int may_use_native;
 #ifdef _MSC_VER
 #include <stdlib.h>
 
+#if _MSC_VER >= 1600
+#include <stdint.h>
+#endif
+
 #ifndef INT64_MAX
 #define INT64_MAX _I64_MAX
 #endif

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -133,9 +133,11 @@ sub postamble {
     $author = join( ', ', @$author ) if ref $author;
     $author =~ s/'/'\''/g;
 
+    $author = ($^O eq 'MSWin32') ? qq{"$author"} : qq{'$author'};
+
     return <<"MAKE_FRAG";
 c_api.h: c_api.decl
-	perl -MModule::CAPIMaker -emake_c_api module_name=\$(NAME) module_version=\$(VERSION) author='$author'
+	perl -MModule::CAPIMaker -emake_c_api module_name=\$(NAME) module_version=\$(VERSION) author=$author
 MAKE_FRAG
 }
 


### PR DESCRIPTION
See [build failure](http://www.cpantesters.org/cpan/report/15de1b4f-6c16-1014-bcb1-9173bd391315) on Windows.

Also, when building from git checkout, `Makefile.PL` used single quotes to quote author names which upsets cmd.exe. Use double-quotes on Windows.