### PR TITLE
Fix URL for pack documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Perl.
 
 - uint64\_to\_BER($u64)
 
-    Encodes the given unsigned integer in BER format (see ["pack" in perlfunc](https://metacpan.org/pod/perlfunc#pack-TEMPLATE-LIST).
+    Encodes the given unsigned integer in BER format (see ["pack" in perlfunc](https://metacpan.org/pod/perlfunc#pack-TEMPLATE-LIST)).
 
 - BER\_to\_uint64($str)
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Perl.
 
 - uint64\_to\_BER($u64)
 
-    Encodes the given unsigned integer in BER format (see ["pack" in perlfunc](https://metacpan.org/pod/perlfunc#pack)).
+    Encodes the given unsigned integer in BER format (see ["pack" in perlfunc](https://metacpan.org/pod/perlfunc#pack-TEMPLATE-LIST).
 
 - BER\_to\_uint64($str)
 


### PR DESCRIPTION
The id is `pack-TEMPLATE-LIST` not just `pack`. 

And, without the direct link to the element, finding the documentation for a particular function can be tedious for newbies. (This is one reason I prefer [perldoc.perl.org](http://perldoc.perl.org/functions/pack.html), but I understand MetaCPAN is the preferred way these days.)