### PR TITLE
Fix for cygwin.

### DIFF
--- a/Int64.xs
+++ b/Int64.xs
@@ -47,9 +47,11 @@ static int may_use_native;
 #endif
 
 #ifdef __INT64
+#ifndef __CYGWIN__
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
 #define HAVE_INT64
+#endif
 #endif
 
 #ifdef INT64_DI


### PR DESCRIPTION
Modern cygwin has `<stdint.h>`, so it doesn't need to definte `int64_t` in terms of `__int64`, in fact it appears to not have `__int64`.

This is the error that I was seeing:

```
xian-x86_64% make
gcc -c   -DPERL_USE_SAFE_PUTENV -U__STRICT_ANSI__ -ggdb -O2 -pipe -Wimplicit-function-declaration -fdebug-prefix-map=/mnt/share/maint/perl.x86_64/build=/usr/src/debug/perl-5.22.1-1 -fdebug-prefix-map=/mnt/share/maint/perl.x86_64/src/perl-5.22.1=/usr/src/debug/perl-5.22.1-1 -fwrapv -fno-strict-aliasing -fstack-protector-strong -D_FORTIFY_SOURCE=2 -DUSEIMPORTLIB -O3   -DVERSION=\"0.54\" -DXS_VERSION=\"0.54\"  "-I/usr/lib/perl5/5.22/x86_64-cygwin-threads/CORE"  -DINT64_BACKEND_IV -DINT64_T -DHAS_STDINT_H Int64.c
Int64.xs:50:9: error: unknown type name ‘__int64’
 typedef __int64 int64_t;
         ^
Int64.xs:50:17: error: conflicting types for ‘int64_t’
 typedef __int64 int64_t;
                 ^
In file included from /usr/include/sys/types.h:63:0,
                 from /usr/lib/perl5/5.22/x86_64-cygwin-threads/CORE/perl.h:699,
                 from Int64.xs:6:
/usr/include/sys/_stdint.h:37:19: note: previous declaration of ‘int64_t’ was here
 typedef __int64_t int64_t ;
                   ^
Int64.xs:51:26: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘uint64_t’
 typedef unsigned __int64 uint64_t;
                          ^
Makefile:351: recipe for target 'Int64.o' failed
make: *** [Int64.o] Error 1
```

Happy to try out other solutions if you want to handle this differently.
